### PR TITLE
WIP: Support Firefox web extenstions

### DIFF
--- a/src/background/notifications.js
+++ b/src/background/notifications.js
@@ -94,7 +94,15 @@ class SingletonPage
 
   focus() {
     const focusWindow = tab => chrome.windows.update(tab.windowId, { focused: true });
-    const focusTab = id => chrome.tabs.update(id, { active: true, highlighted: true }, focusWindow);
+    const focusTab = id => {
+      try {
+        chrome.tabs.update(id, { active: true, highlighted: true }, focusWindow);
+      } catch (e) {
+        // Firefox doesn't currently allow setting highlighted for chrome.tabs.update()
+        // TODO: File a FF bug for this
+        chrome.tabs.update(id, { active: true }, focusWindow);
+      }
+    };
     focusTab(this._tabId);
   }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -40,5 +40,11 @@
     "128": "icons/128.png"
   },
   "minimum_chrome_version": "55",
-  "content_security_policy": "script-src 'self'; object-src 'self'"
+  "content_security_policy": "script-src 'self'; object-src 'self'",
+  "applications": {
+    "gecko": {
+      "id": "firefox-addon@marinara.com",
+      "strict_min_version": "57.0"
+    }
+  }
 }


### PR DESCRIPTION
Firefox now has support for a web extensions API that mimics what's in Chrome.

With Firefox Quantum coming out in November I was curious to see if Marinara works in Firefox now, and surprise it does! I'm still testing so I'm sure I'll find more issues but this is enough to get it installed and running without any errors. Will use it for a few days to see how it goes, but any feedback now is welcome.