### PR TITLE
Enable notifications in Firefox Quantum

### DIFF
--- a/src/background/async.js
+++ b/src/background/async.js
@@ -51,8 +51,23 @@ class AsyncNotifications
 {
   static async create(options) {
     return new Promise((resolve, reject) => {
-      chrome.notifications.create('', options, id => resolve(id));
+      try {
+        chrome.notifications.create('', options, id => resolve(id));        
+      } catch (e) {
+        // This is failing on Firefox as it doesn't support the buttons option for the notification and raises an exception when this is called. (see http://bugzil.la/1190681)
+        // Try again with a subset of options that are more broadly supported
+        chrome.notifications.create('', AsyncNotifications.compatible_options(options), id => resolve(id));
+      }
     });
+  }
+
+  static compatible_options(options) {
+    return {
+      type: options.type,
+      iconUrl: options.iconUrl,
+      title: options.title,
+      message: options.message
+    };
   }
 }
 

--- a/src/background/async.js
+++ b/src/background/async.js
@@ -56,18 +56,15 @@ class AsyncNotifications
       } catch (e) {
         // This is failing on Firefox as it doesn't support the buttons option for the notification and raises an exception when this is called. (see http://bugzil.la/1190681)
         // Try again with a subset of options that are more broadly supported
-        chrome.notifications.create('', AsyncNotifications.compatible_options(options), id => resolve(id));
+        const compatible_options = {
+          type: options.type,
+          iconUrl: options.iconUrl,
+          title: options.title,
+          message: options.message
+        };
+        chrome.notifications.create('', compatible_options, id => resolve(id));
       }
     });
-  }
-
-  static compatible_options(options) {
-    return {
-      type: options.type,
-      iconUrl: options.iconUrl,
-      title: options.title,
-      message: options.message
-    };
   }
 }
 


### PR DESCRIPTION
Without support for some of the `NotificationOptions` we use in Chrome, such as `buttons` the call to `chrome.notifications.create()` was failing in Firefox Quantum.

This PR addresses that issue so the notifications work now. We should monitor the Firefox bug for notification buttons and consider enabling them when it is resolved:

https://bugzilla.mozilla.org/show_bug.cgi?id=1190681