### PR TITLE
Support for a start focusing time

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -113,6 +113,14 @@
     "message": "Long Break",
     "description": "Long Break section header. Shown on the settings page."
   },
+  "startup_title": {
+    "message": "Start up",
+    "description": "Start up section header. Shown on the settings page."
+  },
+  "time": {
+    "message": "Time:",
+    "description": "Time input label. Shown on the settings page."
+  },
   "duration": {
     "message": "Duration:",
     "description": "Timer duration label. Shown on the settings page."

--- a/src/background/settings.js
+++ b/src/background/settings.js
@@ -66,7 +66,7 @@ class StorageManager extends EventEmitter
 class MarinaraSchema
 {
   get version() {
-    return 4;
+    return 5;
   }
 
   get default() {
@@ -98,6 +98,9 @@ class MarinaraSchema
           tab: true,
           sound: null
         }
+      },
+      startUp: {
+        time: '',
       },
       version: this.version
     };
@@ -182,5 +185,15 @@ class MarinaraSchema
     v4.longBreak.timerSound = null;
 
     return v4;
+  }
+
+  from4To5(v4) {
+    let v5 = clone(v4);
+    v5.version = 5;
+
+    v5.startUp = {
+      time: '',
+    };
+    return v5;
   }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,6 +9,7 @@
   "homepage_url": "https://github.com/schmich/marinara",
   "offline_enabled": true,
   "permissions": [
+    "alarms",
     "contextMenus",
     "storage",
     "notifications"

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -164,6 +164,15 @@
               </div>
             </fieldset>
           </div>
+          <div class="section">
+            <h2 data-t="startup_title"></h2>
+            <p class="field">
+              <label>
+                <span data-t="time"></span>
+                <input type="time" class="time" id="startup-time" autofocus>
+              </label>
+            </p>
+          </div>
         </form>
       </div>
       <div class="tab-page" id="history-page">

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -155,6 +155,11 @@ function loadSettingGroup(name, settings, notificationSounds, timerSounds) {
   appendNotificationSounds(soundsSelect, sounds, settings.notifications.sound);
 }
 
+function loadSettingGroupStartUp(settings) {
+  let time = document.getElementById(`startup-time`);
+  time.value = settings.time;
+}
+
 async function loadSettings() {
   let settings = await BackgroundClient.getSettings();
   let notificationSounds = await BackgroundClient.getNotificationSounds();
@@ -163,6 +168,7 @@ async function loadSettings() {
   loadSettingGroup('focus', settings.focus, notificationSounds, timerSounds);
   loadSettingGroup('short-break', settings.shortBreak, notificationSounds, timerSounds);
   loadSettingGroup('long-break', settings.longBreak, notificationSounds, timerSounds);
+  loadSettingGroupStartUp(settings.startUp);
 
   let longBreakInterval = document.getElementById('long-break-interval');
 
@@ -215,10 +221,19 @@ function getSettingGroup(name) {
   };
 }
 
+function getSettingGroupStartUp() {
+  let time = document.getElementById(`startup-time`);
+
+  return {
+    time: time.value,
+  };
+}
+
 async function saveSettings(settings) {
   settings.focus = getSettingGroup('focus');
   settings.shortBreak = getSettingGroup('short-break');
   settings.longBreak = getSettingGroup('long-break');
+  settings.startUp = getSettingGroupStartUp();
 
   let longBreakInterval = document.getElementById('long-break-interval');
   settings.longBreak.interval = longBreakInterval.value;
@@ -364,11 +379,9 @@ async function load() {
   let version = document.getElementById('version');
   version.innerText = manifest.version;
 
-  let inputs = document.querySelectorAll('#settings input[type="checkbox"], #settings select');
-  inputs.forEach(input => input.addEventListener('change', () => saveSettings(settings)));
-
-  let texts = document.querySelectorAll('#settings input[type="text"]');
-  texts.forEach(text => text.addEventListener('input', () => saveSettings(settings)));
+  let settings_el = document.getElementById('settings');
+  settings_el.addEventListener('input', () => saveSettings(settings));
+  settings_el.addEventListener('change', () => saveSettings(settings));
 
   let hash = window.location.hash || '#settings';
   selectTab(hash);


### PR DESCRIPTION
As suggested by @joshakeman in #157 for some of us it is easy to forget (or resist) that first pomodoro of the day. This PR adds support for automatically starting a focus session at a specific time each day.

There is a little bit more I would like to add, specifically sound/notification, but I thought I would check first if the approach I've used looks good to you.