### PR TITLE
Add basic "reminders" functionality for when extension starts (#184)

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -121,6 +121,18 @@
     "message": "Schedule the first Pomodoro of the day to automatically start at the specified time.",
     "description": "Autostart setting description. Shown on the settings page."
   },
+  "reminders_title": {
+    "message": "Reminders",
+    "description": "Reminders section header. Shown on the settings page."
+  },
+  "reminders_description": {
+    "message": "Reminders to start a new cycle.",
+    "description": "Reminders section description. Shown on the settings page."
+  },
+  "reminder_on_start": {
+    "message": "When Chrome starts:",
+    "description": "Reminder options for when Chrome starts. Shown on the settings page."
+  },
   "time": {
     "message": "Time:",
     "description": "Time input label. Shown on the settings page."

--- a/src/_locales/pt_BR/messages.json
+++ b/src/_locales/pt_BR/messages.json
@@ -113,6 +113,18 @@
     "message": "Intervalo Longo",
     "description": "Long Break section header. Shown on the settings page."
   },
+  "reminders_title": {
+    "message": "Lembretes",
+    "description": "Reminders section header. Shown on the settings page."
+  },
+  "reminders_description": {
+    "message": "Lembretes para começar um novo ciclo",
+    "description": "Reminders section description. Shown on the settings page."
+  },
+  "reminder_on_start": {
+    "message": "Quando abrir o navegador:",
+    "description": "Reminder options for when Chrome starts. Shown on the settings page."
+  },
   "duration": {
     "message": "Duração:",
     "description": "Timer duration label. Shown on the settings page."

--- a/src/background/settings.js
+++ b/src/background/settings.js
@@ -72,7 +72,7 @@ class StorageManager extends EventEmitter
 class MarinaraSchema
 {
   get version() {
-    return 5;
+    return 6;
   }
 
   get default() {
@@ -107,6 +107,10 @@ class MarinaraSchema
       },
       autostart: {
         time: null,
+      },
+      reminders: {
+        notification: true,
+        tab: true
       },
       version: this.version
     };
@@ -202,5 +206,17 @@ class MarinaraSchema
     };
 
     return v5;
+  }
+
+  from5To6(v5) {
+    let v6 = clone(v5);
+    v6.version = 6;
+
+    v6.reminders = {
+      notification: null,
+      tab: null
+    };
+
+    return v6;
   }
 }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -174,6 +174,25 @@
               </label>
             </p>
           </div>
+          <div class="section">
+            <h2 data-t="reminders_title"></h2>
+            <p data-t="reminders_description"></p>
+            <p data-t="reminder_on_start"></p>
+            <div class="group">
+              <p class="field">
+                <label>
+                  <input type="checkbox" id="reminder-notification">
+                  <span data-t="show_desktop_notification"></span>
+                </label>
+              </p>
+              <p class="field">
+                <label>
+                  <input type="checkbox" id="reminder-tab">
+                  <span data-t="show_new_tab_notification"></span>
+                </label>
+              </p>
+            </div>
+          </div>
         </form>
       </div>
       <div class="tab-page" id="history-page">

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -160,6 +160,13 @@ function loadSettingGroupAutostart(settings) {
   time.value = settings.time;
 }
 
+function loadSettingGroupReminders(settings) {
+  let notif = document.getElementById('reminder-notification');
+  let tab = document.getElementById('reminder-tab');
+  notif.checked = settings.notification;
+  tab.checked = settings.tab;
+}
+
 async function loadSettings() {
   let settings = await BackgroundClient.getSettings();
   let notificationSounds = await BackgroundClient.getNotificationSounds();
@@ -169,6 +176,7 @@ async function loadSettings() {
   loadSettingGroup('short-break', settings.shortBreak, notificationSounds, timerSounds);
   loadSettingGroup('long-break', settings.longBreak, notificationSounds, timerSounds);
   loadSettingGroupAutostart(settings.autostart);
+  loadSettingGroupReminders(settings.reminders);
 
   let longBreakInterval = document.getElementById('long-break-interval');
 
@@ -228,11 +236,21 @@ function getSettingGroupAutostart() {
   };
 }
 
+function getSettingGroupReminders() {
+  let notif = document.getElementById('reminder-notification');
+  let tab = document.getElementById('reminder-tab');
+  return {
+    notification: notif.checked || null,
+    tab: notif.checked || null
+  };
+}
+
 async function saveSettings(settings) {
   settings.focus = getSettingGroup('focus');
   settings.shortBreak = getSettingGroup('short-break');
   settings.longBreak = getSettingGroup('long-break');
   settings.autostart = getSettingGroupAutostart();
+  settings.reminders = getSettingGroupReminders();
 
   let longBreakInterval = document.getElementById('long-break-interval');
   settings.longBreak.interval = longBreakInterval.value;


### PR DESCRIPTION
This is my implementation for the basic "reminder" feature I suggested on issue #184. It only includes two new options for showing a desktop notification and/or the new tab notification for starting a new cycle when the extension loads. 

It's my first time working on a Chrome extension and maybe I made some mistakes, please let me know if there is something I could do better or if you don't think this feature should be part of your repo.