### PR TITLE
add ability to view specific date range within Pomodoro history

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -55,3 +55,4 @@ Marinara is open source software and is built by volunteers from around the worl
 - [Iosif Dan](https://github.com/danutiosif): Romanian translation
 - [Brian L](https://github.com/brianl9995): Spanish translation
 - [Wesley Matos](https://github.com/wricke): Portuguese (Brazil) translation
+- [Pat Finnigan](https://github.com/finnigantime): History Tab enhancement

--- a/package/_locales/en/messages.json
+++ b/package/_locales/en/messages.json
@@ -325,6 +325,18 @@
     "message": "Finish a Pomodoro to see your history",
     "description": "Placeholder for history heatmap when no Pomodoros have been completed. Shown on the settings-history page."
   },
+  "history_date_range": {
+    "message": "History Date Range",
+    "description": "Title for section for selecting the [start, end] date range of Pomodoro history data to display. Shown on the settings-history page."
+  },
+  "history_date_range_start": {
+    "message": "Start",
+    "description": "Label for the Date input for the start of the date range of Pomodoro history data to display. Shown on the settings-history page."
+  },
+  "history_date_range_end": {
+    "message": "End",
+    "description": "Label for the Date input for the end of the date range of Pomodoro history data to display. Shown on the settings-history page."
+  },
   "daily_tooltip": {
     "message": "$pomodoros$ between $start$—$end$",
     "description": "Tooltip for daily distribution chart. Shown on the settings-history page.",

--- a/src/Messages.js
+++ b/src/Messages.js
@@ -273,6 +273,15 @@ class Messages
   get history() {
     return chrome.i18n.getMessage('history', []);
   }
+  get history_date_range() {
+    return chrome.i18n.getMessage('history_date_range', []);
+  }
+  get history_date_range_start() {
+    return chrome.i18n.getMessage('history_date_range_start', []);
+  }
+  get history_date_range_end() {
+    return chrome.i18n.getMessage('history_date_range_end', []);
+  }
   get history_empty_placeholder() {
     return chrome.i18n.getMessage('history_empty_placeholder', []);
   }

--- a/src/background/Services.js
+++ b/src/background/Services.js
@@ -69,8 +69,8 @@ class HistoryService extends Service
     this.history = history;
   }
 
-  async getStats(since) {
-    return await this.history.stats(since);
+  async getStats(since, dateRangeStart, dateRangeEnd) {
+    return await this.history.stats(since, dateRangeStart, dateRangeEnd);
   }
 
   async getCSV() {


### PR DESCRIPTION
This allows the history tab Pomodoro data to be filtered to a specific date range. This allows the user to, for example, visualize their Pomodoro history for just 2019.

- The timestamp calculation on the beginning/end dates may be slightly off - I wasn't rigorous about zeroing out hh:mm:ss to the start of the day or dealing with timezones. But other than that it should work and most of the time you'd care to view data over a longer multi-day range, and you can always choose a day earlier or later than the range to safely include all data.
- I don't have much experience with Chrome extensions or Vue so not sure I did things correctly. I went off existing patterns I saw in the codebase. Feel free to call out anything weird.
- I only added locale strings for English. Is that okay?


before:

<img width="741" alt="Screen Shot 2020-08-01 at 8 54 02 PM" src="https://user-images.githubusercontent.com/1305608/89115123-34a9f780-d439-11ea-928f-95c2f4dc8da7.png">


after:

<img width="1023" alt="Screen Shot 2020-08-01 at 8 45 33 PM" src="https://user-images.githubusercontent.com/1305608/89115105-193eec80-d439-11ea-8364-7b0b9fc97607.png">

<img width="927" alt="Screen Shot 2020-08-01 at 8 45 48 PM" src="https://user-images.githubusercontent.com/1305608/89115106-1ba14680-d439-11ea-9303-e55cb109e205.png">

<img width="949" alt="Screen Shot 2020-08-01 at 8 46 36 PM" src="https://user-images.githubusercontent.com/1305608/89115107-1c39dd00-d439-11ea-8606-4b6cfd3f8970.png">

