### PR TITLE
add swahili translation

### DIFF
--- a/package/_locales/sw/messages.json
+++ b/package/_locales/sw/messages.json
@@ -1,0 +1,1032 @@
+{
+  "app_name": {
+    "message": "Marinara: Pomodoro msaidizi",
+    "description": "The name of the application. Shown in the web store."
+  },
+  "app_name_short": {
+    "message": "Marinara",
+    "description": "The short name of the application. Shown at the top of the dropdown menu."
+  },
+  "app_desc": {
+    "message": "Pomodoro msaidizi wa usimamizi wa wakati",
+    "description": "The short description of the application. Shown in the web store."
+  },
+  "chrome_web_store_description": {
+    "message": "•likizo fupi na likizo ndefu\n•zana ya icon na muda wa kuhesabu\n•fuatilia historia ya Pomodoro na takwimu\n•sanidi muda wa mapumziko\n•arifa za desktop na tabo\n•arifa za sauti na sauti 20\n•wakati wa sauti\n•ratiba ya saa moja kwa moja\n•wazi chanzo laini",
+    "description": "Detailed extension description shown to users in the Chrome Web Store."
+  },
+  "pomodoro_assistant": {
+    "message": "Msaidizi wa Poromodoro",
+    "description": "Marinara title tagline. Shown on the settings-feedback page."
+  },
+  "start_pomodoro_cycle": {
+    "message": "Anza mzunguko wa pomodoro",
+    "description": "Menu entry to start a new Pomodoro cycle. Shown in the dropdown menu."
+  },
+  "restart_pomodoro_cycle": {
+    "message": "Anzisha tena mzunguko wa Pomodoro",
+    "description": "Menu entry to restart the current Pomodoro cycle. Shown in the dropdown menu."
+  },
+  "restart_timer": {
+    "message": "Anzisha tena muda",
+    "description": "Menu entry to restart the current timer. Shown in the dropdown menu."
+  },
+  "start_focusing": {
+    "message": "Anza kuzingatia",
+    "description": "Start a focus session. Shown in the dropdown menu, timer expiration page, and in browser notifications."
+  },
+  "start_short_break": {
+    "message": "Anza likizo fupi",
+    "description": "Start a short break session. Shown in the dropdown menu, timer expiration page, and in browser notifications."
+  },
+  "start_break": {
+    "message": "Anza likizo",
+    "description": "Start a break session. Shown in the dropdown menu, timer expiration page, and in browser notifications."
+  },
+  "start_long_break": {
+    "message": "Anza likizo ndefu",
+    "description": "Start a long break session. Shown in the dropdown menu, timer expiration page, and in browser notifications."
+  },
+  "stop_timer": {
+    "message": "Simamisha muda",
+    "description": "Menu entry to stop the current timer. Shown in the dropdown menu."
+  },
+  "pause_timer": {
+    "message": "Pozi muda",
+    "description": "Menu entry to pause the current timer. Shown in the dropdown menu."
+  },
+  "resume_timer": {
+    "message": "Endelea muda",
+    "description": "Menu entry to resume the paused timer. Shown in the dropdown menu."
+  },
+  "pomodoro_history": {
+    "message": "Historia ya Pomodoro",
+    "description": "Menu entry to view Pomodoro history/stats. Shown in the dropdown menu."
+  },
+  "timer_paused": {
+    "message": "Muda umepozi",
+    "description": "Tooltip to indicate the current timer is paused. Shown when hovering over the toolbar icon."
+  },
+  "pomodoro_count_zero": {
+    "message": "Hakuna Pomodoros",
+    "description": "Label for zero Pomodoros. Shown on the expiration page."
+  },
+  "pomodoro_count_one": {
+    "message": "Pomodoro moja",
+    "description": "Label for a single Pomodoro. Shown on the expiration page."
+  },
+  "pomodoro_count_many": {
+    "message": "$hesabu$ Pomodoros",
+    "description": "Label for many Pomodoros. Shown on the expiration page.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "10"
+      }
+    }
+  },
+  "marinara_pomodoro_assistant": {
+    "message": "Marinara: msaidizi wa Pomodoro",
+    "description": "Settings page title."
+  },
+  "settings": {
+    "message": "mipangilio",
+    "description": "Settings tab. Shown on the settings page."
+  },
+  "history": {
+    "message": "Historia",
+    "description": "History tab. Shown on the settings page."
+  },
+  "feedback": {
+    "message": "Maoni",
+    "description": "Feedback tab and section header. Shown on the settings page."
+  },
+  "focus": {
+    "message": "Zingatia",
+    "description": "Focus section header. Shown on the settings page."
+  },
+  "short_break": {
+    "message": "Likizo fupi",
+    "description": "Short Break section header. Shown on the settings page."
+  },
+  "long_break": {
+    "message": "Likizo ndefu",
+    "description": "Long Break section header. Shown on the settings page."
+  },
+  "autostart_title": {
+    "message": "Otomati",
+    "description": "Autostart section header. Shown on the settings page."
+  },
+  "autostart_description": {
+    "message": "Panga Pomodoro ili kuanza otomatiki kwa wakati uliowekwa.",
+    "description": "Autostart setting description. Shown on the settings page."
+  },
+  "autostart_notification_title": {
+    "message": "Otomati Pomodoro",
+    "description": "Autostart notification title. Shown in browser notifications when the autostart Pomodoro starts."
+  },
+  "autostart_notification_message": {
+    "message": "Pomodoro iliyopangwa ilianzishwa moja kwa moja",
+    "description": "Autostart notification message. Shown in browser notifications when the autostart Pomodoro starts."
+  },
+  "time": {
+    "message": "Muda:",
+    "description": "Time input label. Shown on the settings page."
+  },
+  "duration": {
+    "message": "Kipindi:",
+    "description": "Timer duration label. Shown on the settings page."
+  },
+  "minutes": {
+    "message": "Dakika",
+    "description": "Minutes label for timer duration. Shown on the settings page."
+  },
+  "timer_sound_label": {
+    "message": "Sauti ya saa",
+    "description": "Timer sound label. Shown on the settings page."
+  },
+  "hover_preview": {
+    "message": "Pitisha kuhakiki",
+    "description": "Hover to preview note. Shown on the settings page."
+  },
+  "speed_label": {
+    "message": "Spidi:",
+    "description": "Timer sound speed label. Shown on the settings page."
+  },
+  "bpm": {
+    "message": "Biti kwa dakika",
+    "description": "Beats per minute; speed unit for timer sound. Shown on the settings page."
+  },
+  "none": {
+    "message": "Hakun",
+    "description": "The 'no sound' option. Represents nothing selected. Shown on the settings page."
+  },
+  "countdown_timer": {
+    "message": "muda wa kuhesabu",
+    "description": "Countdown timer label. Shown on the settings page."
+  },
+  "width": {
+    "message": "Upana",
+    "description": "Width input placeholder. Refers to countdown window width in pixels."
+  },
+  "height": {
+    "message": "Urefu",
+    "description": "Height input placeholder. Refers to countdown window height in pixels."
+  },
+  "do_not_show": {
+    "message": "Usioneshe",
+    "description": "Countdown timer visibility option. Shown on the settings page."
+  },
+  "show_in_tab": {
+    "message": "Onesha kwenye tab mpya",
+    "description": "Countdown timer visibility option. Shown on the settings page."
+  },
+  "show_in_window": {
+    "message": "onyesha kwenye kidirisha cha kidukizo",
+    "description": "Countdown timer visibility option. Shown on the settings page."
+  },
+  "fullscreen": {
+    "message": "Skrini kamili",
+    "description": "Countdown timer resolution option for a fullscreen (maximized) countdown timer. Shown on the settings page."
+  },
+  "custom": {
+    "message": "Mila",
+    "description": "Countdown timer resolution option. Lets the user specify their own countdown window resolution. Shown on the settings page."
+  },
+  "countdown_autoclose_tab": {
+    "message": "Funga tab kipindi kikiisha",
+    "description": "Countdown timer option. Specifies if the countdown tab should close when the session ends. Shown on the settings page."
+  },
+  "countdown_autoclose_window": {
+    "message": "Funga dirisha kipindi kikiisha",
+    "description": "Countdown timer option. Specifies if the countdown window should close when the session ends. Shown on the settings page."
+  },
+  "when_complete": {
+    "message": "Ikiisha",
+    "description": "Section label for events to fire when timer completes. Shown on the settings page."
+  },
+  "show_desktop_notification": {
+    "message": "Onesha arifu ya desktopu",
+    "description": "Desktop notification option. Shown on the settings page."
+  },
+  "show_new_tab_notification": {
+    "message": "Nioneshe muarifu mpya wa tab",
+    "description": "New tab notification option. Shown on the settings page."
+  },
+  "play_audio_notification": {
+    "message": "Cheza sauti:",
+    "description": "Audio notification label. Shown on the settings page."
+  },
+  "take_a_long_break_setting": {
+    "message": "Chukua likizo ndefu",
+    "description": "Long break settings label. Shown on the settings page."
+  },
+  "never": {
+    "message": "Kamwe",
+    "description": "Long break option. Shown in the long break dropdown on the settings page."
+  },
+  "every_2nd_break": {
+    "message": "kila mapumziko ya pili (kubadilika)",
+    "description": "Long break option. Shown in the long break dropdown on the settings page."
+  },
+  "every_3rd_break": {
+    "message": "Kila mapumziko ya tatu",
+    "description": "Long break option. Shown in the long break dropdown on the settings page."
+  },
+  "every_4th_break": {
+    "message": "Kila mapumziko ya nne",
+    "description": "Long break option. Shown in the long break dropdown on the settings page."
+  },
+  "every_5th_break": {
+    "message": "Kila mapumziko ya tano",
+    "description": "Long break option. Shown in the long break dropdown on the settings page."
+  },
+  "every_6th_break": {
+    "message": "Kila mapumziko ya sita",
+    "description": "Long break option. Shown in the long break dropdown on the settings page."
+  },
+  "every_7th_break": {
+    "message": "Kila mapumziko ya saba",
+    "description": "Long break option. Shown in the long break dropdown on the settings page."
+  },
+  "every_8th_break": {
+    "message": "Kila mapumziko ya nane",
+    "description": "Long break option. Shown in the long break dropdown on the settings page."
+  },
+  "every_9th_break": {
+    "message": "Kila mapumziko ya tisa",
+    "description": "Long break option. Shown in the long break dropdown on the settings page."
+  },
+  "every_10th_break": {
+    "message": "Kila mapumziko ya kumi",
+    "description": "Long break option. Shown in the long break dropdown on the settings page."
+  },
+  "tone": {
+    "message": "Sauti",
+    "description": "Sound name. Shown in the audio notification dropdown in settings."
+  },
+  "electronic_chime": {
+    "message": "Chime ya kielekroniki",
+    "description": "Sound name. Shown in the audio notification dropdown in settings."
+  },
+  "today": {
+    "message": "Leo",
+    "description": "Pomodoro stats label. Shown on the settings-history page."
+  },
+  "this_week": {
+    "message": "Wiki hii",
+    "description": "Pomodoro stats label. Shown on the settings-history page."
+  },
+  "this_month": {
+    "message": "Mwezi huu",
+    "description": "Pomodoro stats label. Shown on the settings-history page."
+  },
+  "total": {
+    "message": "Jumla",
+    "description": "Pomodoro stats label. Shown on the settings-history page."
+  },
+  "daily_distribution": {
+    "message": "usambazaji wa kila siku",
+    "description": "Daily distribution section header. Shown on the settings-history page."
+  },
+  "weekly_distribution": {
+    "message": "Usambazaji wa kila wiki",
+    "description": "Weekly distribution section header. Shown on the settings-history page."
+  },
+  "last_9_months": {
+    "message": "$hesabu$ ya miezi tisa iliyopita",
+    "description": "Last 9 months section header. Shown on the settings-history page.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "No Pomodoros"
+      }
+    }
+  },
+  "daily_empty_placeholder": {
+    "message": "Maliza Pomodoro kuona takwimu zako za kila siku",
+    "description": "Placeholder for daily stats when no Pomodoros have been completed. Shown on the settings-history page."
+  },
+  "weekly_empty_placeholder": {
+    "message": "Maliza Pomodoro kuona takwimu zako za kila wiki",
+    "description": "Placeholder for weekly stats when no Pomodoros have been completed. Shown on the settings-history page."
+  },
+  "history_empty_placeholder": {
+    "message": "Maliza Pomodoro kuona historia yako",
+    "description": "Placeholder for history heatmap when no Pomodoros have been completed. Shown on the settings-history page."
+  },
+  "daily_tooltip": {
+    "message": "$pomodoros$ katikati $anza$-$mwisho$",
+    "description": "Tooltip for daily distribution chart. Shown on the settings-history page.",
+    "placeholders": {
+      "pomodoros": {
+        "content": "$1",
+        "example": "15 Pomodoros"
+      },
+      "start": {
+        "content": "$2",
+        "example": "9:00a"
+      },
+      "end": {
+        "content": "$3",
+        "example": "10:00a"
+      }
+    }
+  },
+  "weekly_tooltip": {
+    "message": "$pomodoros$ ya $siku$",
+    "description": "Tooltip for weekly distribution chart. Shown on the settings-history page.",
+    "placeholders": {
+      "pomodoros": {
+        "content": "$1",
+        "example": "25 Pomodoros"
+      },
+      "day": {
+        "content": "$2",
+        "example": "Mondays"
+      }
+    }
+  },
+  "heatmap_tooltip": {
+    "message": "$pomodoros$ ya $tarehe$",
+    "description": "Tooltip for heatmap chart. Shown on the settings-history page.",
+    "placeholders": {
+      "pomodoros": {
+        "content": "$1",
+        "example": "25 Pomodoros"
+      },
+      "date": {
+        "content": "$2",
+        "example": "Jun 07, 2017"
+      }
+    }
+  },
+  "decimal_separator": {
+    "message": ".",
+    "description": "Separator for fractional numbers (e.g. three-and-a-half: 3.5)."
+  },
+  "thousands_separator": {
+    "message": ",",
+    "description": "Group separator for large numbers (e.g. two thousand: 2,000)."
+  },
+  "heatmap_date_format": {
+    "message": "%A, %B %d, %Y",
+    "description": "Heatmap tooltip date format. See format options at https://github.com/d3/d3-time-format/blob/master/README.md#locale_format. Shown on the settings-history page."
+  },
+  "hour_format": {
+    "message": "%-I%p",
+    "description": "Hour-only format. See format options at https://github.com/d3/d3-time-format/blob/master/README.md#locale_format. Shown on the daily distribution chart on the settings-history page."
+  },
+  "hour_minute_format": {
+    "message": "%-I:%M%p",
+    "description": "Hour-with-minutes format. See format options at https://github.com/d3/d3-time-format/blob/master/README.md#locale_format. Shown in the daily distribution chart tooltips on the settings-history page."
+  },
+  "date_format": {
+    "message": "%-m/%-d/%Y",
+    "description": "Date-only format. See format options at https://github.com/d3/d3-time-format/blob/master/README.md#locale_format."
+  },
+  "date_time_format": {
+    "message": "%x, %X",
+    "description": "Date-with-time format. See format options at https://github.com/d3/d3-time-format/blob/master/README.md#locale_format."
+  },
+  "time_format": {
+    "message": "%-I:%M:%S %p",
+    "description": "Time-only format. See format options at https://github.com/d3/d3-time-format/blob/master/README.md#locale_format."
+  },
+  "time_period_am": {
+    "message": "a",
+    "description": "12-hour clock AM specifier. Can be empty if 24-hour clock is used. See format options at https://github.com/d3/d3-time-format/blob/master/README.md#locale_format."
+  },
+  "time_period_pm": {
+    "message": "p",
+    "description": "12-hour clock PM specifier. Can be empty if 24-hour clock is used. See format options at https://github.com/d3/d3-time-format/blob/master/README.md#locale_format."
+  },
+  "sunday": {
+    "message": "Jumapili",
+    "description": "Sunday. Shown on the settings-history page."
+  },
+  "monday": {
+    "message": "Jumatatu",
+    "description": "Monday. Shown on the settings-history page."
+  },
+  "tuesday": {
+    "message": "Jumanne",
+    "description": "Tuesday. Shown on the settings-history page."
+  },
+  "wednesday": {
+    "message": "Jumatano",
+    "description": "Wednesday. Shown on the settings-history page."
+  },
+  "thursday": {
+    "message": "Alhamis",
+    "description": "Thursday. Shown on the settings-history page."
+  },
+  "friday": {
+    "message": "Ijumaa",
+    "description": "Friday. Shown on the settings-history page."
+  },
+  "saturday": {
+    "message": "Jumamosi",
+    "description": "Saturday. Shown on the settings-history page."
+  },
+  "sunday_short": {
+    "message": "Jpili",
+    "description": "Sunday abbreviated. Shown on the settings-history page."
+  },
+  "monday_short": {
+    "message": "Jtatu",
+    "description": "Monday abbreviated. Shown on the settings-history page."
+  },
+  "tuesday_short": {
+    "message": "Jnne",
+    "description": "Tuesday abbreviated. Shown on the settings-history page."
+  },
+  "wednesday_short": {
+    "message": "Jtano",
+    "description": "Wednesday abbreviated. Shown on the settings-history page."
+  },
+  "thursday_short": {
+    "message": "Alhamis",
+    "description": "Thursday abbreviated. Shown on the settings-history page."
+  },
+  "friday_short": {
+    "message": "Ijumaa",
+    "description": "Friday abbreviated. Shown on the settings-history page."
+  },
+  "saturday_short": {
+    "message": "Jmosi",
+    "description": "Saturday abbreviated. Shown on the settings-history page."
+  },
+  "january": {
+    "message": "Januari",
+    "description": "January. Shown on the settings-history page."
+  },
+  "february": {
+    "message": "Februari",
+    "description": "February. Shown on the settings-history page."
+  },
+  "march": {
+    "message": "Machi",
+    "description": "March. Shown on the settings-history page."
+  },
+  "april": {
+    "message": "Aprili",
+    "description": "April. Shown on the settings-history page."
+  },
+  "may": {
+    "message": "Mei",
+    "description": "May. Shown on the settings-history page."
+  },
+  "june": {
+    "message": "Juni",
+    "description": "June. Shown on the settings-history page."
+  },
+  "july": {
+    "message": "Julai",
+    "description": "July. Shown on the settings-history page."
+  },
+  "august": {
+    "message": "Agosti",
+    "description": "August. Shown on the settings-history page."
+  },
+  "september": {
+    "message": "Septemba",
+    "description": "September. Shown on the settings-history page."
+  },
+  "october": {
+    "message": "Oktoba",
+    "description": "October. Shown on the settings-history page."
+  },
+  "november": {
+    "message": "Novemba",
+    "description": "November. Shown on the settings-history page."
+  },
+  "december": {
+    "message": "Desemba",
+    "description": "December. Shown on the settings-history page."
+  },
+  "january_short": {
+    "message": "Januari",
+    "description": "January abbreviated. Shown on the settings-history page."
+  },
+  "february_short": {
+    "message": "Februari",
+    "description": "February abbreviated. Shown on the settings-history page."
+  },
+  "march_short": {
+    "message": "Machi",
+    "description": "March abbreviated. Shown on the settings-history page."
+  },
+  "april_short": {
+    "message": "Aprili",
+    "description": "April abbreviated. Shown on the settings-history page."
+  },
+  "may_short": {
+    "message": "Mei",
+    "description": "May abbreviated. Shown on the settings-history page."
+  },
+  "june_short": {
+    "message": "Juni",
+    "description": "June abbreviated. Shown on the settings-history page."
+  },
+  "july_short": {
+    "message": "Julai",
+    "description": "July abbreviated. Shown on the settings-history page."
+  },
+  "august_short": {
+    "message": "Agosti",
+    "description": "August abbreviated. Shown on the settings-history page."
+  },
+  "september_short": {
+    "message": "Septemba",
+    "description": "September abbreviated. Shown on the settings-history page."
+  },
+  "october_short": {
+    "message": "Oktoba",
+    "description": "October abbreviated. Shown on the settings-history page."
+  },
+  "november_short": {
+    "message": "Novemba",
+    "description": "November abbreviated. Shown on the settings-history page."
+  },
+  "december_short": {
+    "message": "Desemba",
+    "description": "December abbreviated. Shown on the settings-history page."
+  },
+  "your_history": {
+    "message": "Historia yako",
+    "description": "Your History section header. Shown on the settings-history page."
+  },
+  "save_as_csv_description": {
+    "message": "Tumia na Excel, Laha za Google, au programu nyingine ya lahajedwali.",
+    "description": "Save as CSV description. Shown on the settings-history page."
+  },
+  "end_date": {
+    "message": "Tarehe ya mwisho",
+    "description": "CSV column header for the Pomodoro's end date in YYYY-MM-DD format."
+  },
+  "end_time": {
+    "message": "Muda wa mwisho (masaa 24)",
+    "description": "CSV column header for the Pomodoro's end time formatted as time on a 24-hour clock."
+  },
+  "end_timestamp": {
+    "message": "Mwisho wa stamp ya muda (Unix)",
+    "description": "CSV column header for the Pomodoro's end time formatted as a Unix timestamp. See https://en.wikipedia.org/wiki/Unix_time."
+  },
+  "end_timezone": {
+    "message": "Mwisho Timezone (Dakika za kukabiliana na UTC)",
+    "description": "CSV column header for the Pomodoro's end timezone defined as the GMT/UTC (Coordinated Universal Time) offset, measured in minutes."
+  },
+  "duration_seconds": {
+    "message": "Kipindi (sekunde)",
+    "description": "CSV column header for the Pomodoro's duration in seconds."
+  },
+  "export": {
+    "message": "usafirishaji",
+    "description": "Export (history) button. Shown on the settings-history page."
+  },
+  "export_description": {
+    "message": "Kwa chelezo au kuagiza kwenye kompyuta nyingine.",
+    "description": "Export history description. Shown on the settings-history page."
+  },
+  "import": {
+    "message": "Kuagiza",
+    "description": "Import (history) button. Shown on the settings-history page."
+  },
+  "import_description": {
+    "message": "Ingiza na unganisha historia ya Pomodoro kutoka faili iliyosafirishwa.",
+    "description": "Import history description. Shown on the settings-history page."
+  },
+  "import_confirmation": {
+    "message": "Historia iliyoingizwa itaunganishwa na historia yako iliyopo. Endelea?",
+    "description": "Import history confirmation prompt. Shown on the settings-history page."
+  },
+  "import_failed": {
+    "message": "Imeshindwa kuleta historia: $kosa$",
+    "description": "Error message shown when history import fails. Shown on the settings-history page.",
+    "placeholders": {
+      "error": {
+        "content": "$1",
+        "example": "Missing Pomodoro data."
+      }
+    }
+  },
+  "clear_history": {
+    "message": "Futa historia",
+    "description": "Clear History button. Shown on the settings-history page."
+  },
+  "clear_history_description": {
+    "message": "Futa kabisa historia yote ya Pomodoro.",
+    "description": "Clear history description. Shown on the settings-history page."
+  },
+  "clear_history_confirmation": {
+    "message": "Futa kabisa historia yote ya Pomodoro?",
+    "description": "Clear history confirmation prompt. Shown when user clicks Clear History on the settings-history page."
+  },
+  "group_pomodoros_minute_buckets": {
+    "message": "Pomodoros ya kikundi ndani ya $hesabu$ ndoo ya dakika",
+    "description": "Daily distribution bucket tooltip. Shown on the settings-history page.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "15"
+      }
+    }
+  },
+  "group_pomodoros_hour_buckets": {
+    "message": "Pomodoros ya kikundi ndani ya $hesabu$ ndoo ya masaa",
+    "description": "Daily distribution bucket tooltip. Shown on the settings-history page.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "min_suffix": {
+    "message": "$hesabu$ Dakika",
+    "description": "Number with minute suffix (abbreviated). Shown on the settings-history page.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "15"
+      }
+    }
+  },
+  "hr_suffix": {
+    "message": "$hesabu$ Saa",
+    "description": "Number with hour suffix (abbreviated). Shown on the settings-history page.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "2"
+      }
+    }
+  },
+  "write_a_review": {
+    "message": "Andika uhakiki",
+    "description": "Link to write a review on Chrome Web Store. Shown on the settings-feedback page."
+  },
+  "report_an_issue": {
+    "message": "Ripoti suala",
+    "description": "Link to report an issue on GitHub. Shown on the settings-feedback page."
+  },
+  "release_notes": {
+    "message": "maelezo ya kutolewa",
+    "description": "Link to GitHub release notes. Shown on the settings-feedback page."
+  },
+  "source_code": {
+    "message": "msimbo wa chanzo",
+    "description": "Link to GitHub source code. Shown on the settings-feedback page."
+  },
+  "attributions": {
+    "message": "Sifa",
+    "description": "Link to audio attributions. Shown on the settings-feedback page."
+  },
+  "license": {
+    "message": "Leseni",
+    "description": "Link to source license. Shown on the settings-feedback page."
+  },
+  "view": {
+    "message": "Mtazamo",
+    "description": "View section header. Shown on the settings-feedback page."
+  },
+  "version": {
+    "message": "Toleo",
+    "description": "Version section header. Shown on the settings-feedback page."
+  },
+  "disclaimer": {
+    "message": "Pomodoro ️️ na Mbinu ya Pomodoro  ️ ni alama za biashara za Francesco Cirillo. Marinara havihusiani na au kuhusishwa na au kupitishwa na Pomodoro®️, Mbinu ya Pomodoro ®️ au Francesco Cirillo.",
+    "description": "Disclaimer footer text. Shown on the settings-feedback page."
+  },
+  "and": {
+    "message": "Na",
+    "description": "Connector of 'Chris Schmich & Contributors'. Shown on the settings-feedback page."
+  },
+  "contributors": {
+    "message": "Wachangiaji",
+    "description": "Part of 'Chris Schmich & Contributors'. Shown on the settings-feedback page."
+  },
+  "completed_today": {
+    "message": "Imemalizika leo",
+    "description": "Label for today's completed Pomodoro count. Shown on the timer expiration page."
+  },
+  "view_history": {
+    "message": "Angalia historia",
+    "description": "View History button text. Shown on the timer expiration page."
+  },
+  "pomodoros_until_long_break": {
+    "message": "$pomodoros$ hadi likizo ndefu",
+    "description": "Pomodoro long break countdown. Shown on the timer expiration page and in browser notifications.",
+    "placeholders": {
+      "pomodoros": {
+        "content": "$1",
+        "example": "5 Pomodoros"
+      }
+    }
+  },
+  "pomodoros_completed_today": {
+    "message": "$pomodoros$ leo",
+    "description": "Daily Pomodoro counter. Should be short enough to fit in browser notification box. Shown in browser notifications.",
+    "placeholders": {
+      "pomodoros": {
+        "content": "$1",
+        "example": "1 Pomodoro"
+      }
+    }
+  },
+  "start_focusing_now": {
+    "message": "Anza kuzingatia sasa",
+    "description": "Notification button text when break timer expires."
+  },
+  "take_a_break": {
+    "message": "Chukua likizo",
+    "description": "Action title. Shown on the timer expiration page and in browser notifications."
+  },
+  "take_a_short_break": {
+    "message": "Chuka likizo fupi",
+    "description": "Action title. Shown on the timer expiration page and in browser notifications."
+  },
+  "take_a_long_break": {
+    "message": "Chukua likizo ndefu",
+    "description": "Action title. Shown on the timer expiration page and in browser notifications."
+  },
+  "start_break_now": {
+    "message": "Anza likizo sasa",
+    "description": "Notification button text when focus timer expires."
+  },
+  "start_short_break_now": {
+    "message": "Anza likizo fupi sasa",
+    "description": "Notification button text when focus timer expires."
+  },
+  "start_long_break_now": {
+    "message": "Anza likizo ndefu sasa",
+    "description": "Notification button text when focus timer expires."
+  },
+  "browser_action_tooltip": {
+    "message": "$kichwa$: $maandishi$",
+    "description": "Browser action tooltip format with title and text. Title is usually timer phase (break, focus) while text is usually timer status (time remaining, paused).",
+    "placeholders": {
+      "title": {
+        "content": "$1",
+        "example": "Short Break"
+      },
+      "text": {
+        "content": "$2",
+        "example": "5m remaining"
+      }
+    }
+  },
+  "n_minutes": {
+    "message": "$hesabu$m",
+    "description": "Badge tooltip and overlay text when timer has least 1 minute remaining.",
+    "placeholders": {
+      "count": {
+        "content": "$1",
+        "example": "15"
+      }
+    }
+  },
+  "less_than_minute": {
+    "message": "<1m",
+    "description": "Badge tooltip and overlay text when timer has less than 1 minute remaining."
+  },
+  "time_remaining": {
+    "message": "$muda$ Uliobaki",
+    "description": "Badge tooltip to show time remaining for current timer.",
+    "placeholders": {
+      "time": {
+        "content": "$1",
+        "example": "5m"
+      }
+    }
+  },
+  "missing_pomodoro_data": {
+    "message": "data ya Pomodoro inayokosekana",
+    "description": "Error when imported history has no Pomodoro information."
+  },
+  "invalid_pomodoro_data": {
+    "message": "Data ya Pomodoro batili",
+    "description": "Error when imported history has invalid Pomodoro information."
+  },
+  "missing_duration_data": {
+    "message": "data ya Kipindi kinachokosekana",
+    "description": "Error when imported history has no Pomodoro duration information."
+  },
+  "invalid_duration_data": {
+    "message": "Data batili ya kipindi",
+    "description": "Error when imported history has invalid duration information."
+  },
+  "missing_timezone_data": {
+    "message": "Data ya timezone inayokosekana",
+    "description": "Error when imported history has no Pomodoro timezone information."
+  },
+  "invalid_timezone_data": {
+    "message": "Data batili ya timezone",
+    "description": "Error when imported history has invalid timezone information."
+  },
+  "mismatched_pomodoro_duration_data": {
+    "message": "Takwimu isiyo na kipimo ya Pomodoro / muda",
+    "description": "Error when imported history has mismatched Pomodoro/duration data."
+  },
+  "mismatched_pomodoro_timezone_data": {
+    "message": "Takwimu isiyo sahihi ya Pomodoro / timezone.",
+    "description": "Error when imported history has mismatched Pomodoro/timezone data."
+  },
+  "pomodoros_imported": {
+    "message": "$pomodoros$ zilizoingizwa",
+    "description": "Count of Pomodoros imported. Shown in prompt after importing/merging Pomodoro history.",
+    "placeholders": {
+      "pomodoros": {
+        "content": "$1",
+        "example": "3 Pomodoros"
+      }
+    }
+  },
+  "help_translate": {
+    "message": "msaada kutafsiri",
+    "description": "Feedback link. Shown on settings-feedback page."
+  },
+  "expire_title": {
+    "message": "Muda umekwisha",
+    "description": "Expiration page title. Shown on the expiration page when a focus/break session completes."
+  },
+  "countdown": {
+    "message": "Kuhesabu",
+    "description": "Countdown page title. Shown on the countdown timer page."
+  },
+  "gong_1": {
+    "message": "Gong 1",
+    "description": "Sound name. Shown in the audio notification dropdown in settings."
+  },
+  "gong_2": {
+    "message": "Gong 2",
+    "description": "Sound name. Shown in the audio notification dropdown in settings."
+  },
+  "computer_magic": {
+    "message": "Uchawi wa kompyuta",
+    "description": "Sound name. Shown in the audio notification dropdown in settings."
+  },
+  "fire_pager": {
+    "message": "pager ya mbele",
+    "description": "Sound name. Shown in the audio notification dropdown in settings."
+  },
+  "glass_ping": {
+    "message": "glasi ya glasi",
+    "description": "Sound name. Shown in the audio notification dropdown in settings."
+  },
+  "music_box": {
+    "message": "sanduku la muziki",
+    "description": "Sound name. Shown in the audio notification dropdown in settings."
+  },
+  "pin_drop": {
+    "message": "kushuka kwa siri",
+    "description": "Sound name. Shown in the audio notification dropdown in settings."
+  },
+  "robot_blip_1": {
+    "message": "Roboti blip 1",
+    "description": "Sound name. Shown in the audio notification dropdown in settings."
+  },
+  "robot_blip_2": {
+    "message": "Roboti blip 2",
+    "description": "Sound name. Shown in the audio notification dropdown in settings."
+  },
+  "ship_bell": {
+    "message": "Kengele ya meli",
+    "description": "Sound name. Shown in the audio notification dropdown in settings."
+  },
+  "train_horn": {
+    "message": "Honi ya treni",
+    "description": "Sound name. Shown in the audio notification dropdown in settings."
+  },
+  "bike_horn": {
+    "message": "Honi ya baiskeli",
+    "description": "Sound name. Shown in the audio notification dropdown in settings."
+  },
+  "bell_ring": {
+    "message": "Kengele",
+    "description": "Sound name. Shown in the audio notification dropdown in settings."
+  },
+  "reception_bell": {
+    "message": "Kengele ya mapokezi",
+    "description": "Sound name. Shown in the audio notification dropdown in settings."
+  },
+  "toaster_oven": {
+    "message": "Tosta ya oveni",
+    "description": "Sound name. Shown in the audio notification dropdown in settings."
+  },
+  "battle_horn": {
+    "message": "Honi ya vita",
+    "description": "Sound name. Shown in the audio notification dropdown in settings."
+  },
+  "ding": {
+    "message": "ding",
+    "description": "Sound name. Shown in the audio notification dropdown in settings."
+  },
+  "dong": {
+    "message": "dong",
+    "description": "Sound name. Shown in the audio notification dropdown in settings."
+  },
+  "ding_dong": {
+    "message": "ding dong",
+    "description": "Sound name. Shown in the audio notification dropdown in settings."
+  },
+  "airplane": {
+    "message": "Ndege",
+    "description": "Sound name. Shown in the audio notification dropdown in settings."
+  },
+  "digital_watch": {
+    "message": "Saa ya dijiti",
+    "description": "Sound name. Shown in the audio notification dropdown in settings."
+  },
+  "analog_alarm_clock": {
+    "message": "Saa ya kengele ya analojia",
+    "description": "Sound name. Shown in the audio notification dropdown in settings."
+  },
+  "digital_alarm_clock": {
+    "message": "Saa ya kengele ya dijitali",
+    "description": "Sound name. Shown in the audio notification dropdown in settings."
+  },
+  "periodic_beat": {
+    "message": "kupigwa mara kwa mara",
+    "description": "Timer sound group name. Shown in the timer sound dropdown in settings."
+  },
+  "stopwatch": {
+    "message": "Saa ya kustop",
+    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
+  },
+  "clock": {
+    "message": "Saa",
+    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
+  },
+  "wall_clock": {
+    "message": "Saa ya ukutani",
+    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
+  },
+  "desk_clock": {
+    "message": "Saa ya mezani",
+    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
+  },
+  "antique_clock": {
+    "message": "Saa ya kale",
+    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
+  },
+  "small_clock": {
+    "message": "Saa ndogo",
+    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
+  },
+  "large_clock": {
+    "message": "Saa kubwa",
+    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
+  },
+  "wristwatch": {
+    "message": "Saa ya mkononi",
+    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
+  },
+  "wind_up_clock": {
+    "message": "Upepo saa",
+    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
+  },
+  "metronome": {
+    "message": "Metronome",
+    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
+  },
+  "wood_block": {
+    "message": "Block ya kuni",
+    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
+  },
+  "pulse": {
+    "message": "Kunde",
+    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
+  },
+  "noise": {
+    "message": "Kelele",
+    "description": "Timer sound group name. Shown in the timer sound dropdown in settings."
+  },
+  "brown_noise": {
+    "message": "Kelele ya kahawia",
+    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
+  },
+  "pink_noise": {
+    "message": "Kelele ya pink",
+    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
+  },
+  "white_noise": {
+    "message": "mipangilio ime",
+    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
+  },
+  "settings_saved": {
+    "message": "mipangilio imehifadhiwa",
+    "description": "Settings Saved notification shown on settings page when settings are saved."
+  },
+  "error_saving_settings": {
+    "message": "Kosa la kuokoa mipangilio: $ujumbe$",
+    "description": "Shown to the user in an alert when settings can't be saved due to user input error or unexpected error.",
+    "placeholders": {
+      "message": {
+        "content": "$1",
+        "example": "Duration must be a positive number."
+      }
+    }
+  }
+}


### PR DESCRIPTION
{
  "app_name": {
    "message": "Marinara: Pomodoro msaidizi",
    "description": "The name of the application. Shown in the web store."
  },
  "app_name_short": {
    "message": "Marinara",
    "description": "The short name of the application. Shown at the top of the dropdown menu."
  },
  "app_desc": {
    "message": "Pomodoro msaidizi wa usimamizi wa wakati",
    "description": "The short description of the application. Shown in the web store."
  },
  "chrome_web_store_description": {
    "message": "•likizo fupi na likizo ndefu\n•zana ya icon na muda wa kuhesabu\n•fuatilia historia ya Pomodoro na takwimu\n•sanidi muda wa mapumziko\n•arifa za desktop na tabo\n•arifa za sauti na sauti 20\n•wakati wa sauti\n•ratiba ya saa moja kwa moja\n•wazi chanzo laini",
    "description": "Detailed extension description shown to users in the Chrome Web Store."
  },
  "pomodoro_assistant": {
    "message": "Msaidizi wa Poromodoro",
    "description": "Marinara title tagline. Shown on the settings-feedback page."
  },
  "start_pomodoro_cycle": {
    "message": "Anza mzunguko wa pomodoro",
    "description": "Menu entry to start a new Pomodoro cycle. Shown in the dropdown menu."
  },
  "restart_pomodoro_cycle": {
    "message": "Anzisha tena mzunguko wa Pomodoro",
    "description": "Menu entry to restart the current Pomodoro cycle. Shown in the dropdown menu."
  },
  "restart_timer": {
    "message": "Anzisha tena muda",
    "description": "Menu entry to restart the current timer. Shown in the dropdown menu."
  },
  "start_focusing": {
    "message": "Anza kuzingatia",
    "description": "Start a focus session. Shown in the dropdown menu, timer expiration page, and in browser notifications."
  },
  "start_short_break": {
    "message": "Anza likizo fupi",
    "description": "Start a short break session. Shown in the dropdown menu, timer expiration page, and in browser notifications."
  },
  "start_break": {
    "message": "Anza likizo",
    "description": "Start a break session. Shown in the dropdown menu, timer expiration page, and in browser notifications."
  },
  "start_long_break": {
    "message": "Anza likizo ndefu",
    "description": "Start a long break session. Shown in the dropdown menu, timer expiration page, and in browser notifications."
  },
  "stop_timer": {
    "message": "Simamisha muda",
    "description": "Menu entry to stop the current timer. Shown in the dropdown menu."
  },
  "pause_timer": {
    "message": "Pozi muda",
    "description": "Menu entry to pause the current timer. Shown in the dropdown menu."
  },
  "resume_timer": {
    "message": "Endelea muda",
    "description": "Menu entry to resume the paused timer. Shown in the dropdown menu."
  },
  "pomodoro_history": {
    "message": "Historia ya Pomodoro",
    "description": "Menu entry to view Pomodoro history/stats. Shown in the dropdown menu."
  },
  "timer_paused": {
    "message": "Muda umepozi",
    "description": "Tooltip to indicate the current timer is paused. Shown when hovering over the toolbar icon."
  },
  "pomodoro_count_zero": {
    "message": "Hakuna Pomodoros",
    "description": "Label for zero Pomodoros. Shown on the expiration page."
  },
  "pomodoro_count_one": {
    "message": "Pomodoro moja",
    "description": "Label for a single Pomodoro. Shown on the expiration page."
  },
  "pomodoro_count_many": {
    "message": "$hesabu$ Pomodoros",
    "description": "Label for many Pomodoros. Shown on the expiration page.",
    "placeholders": {
      "count": {
        "content": "$1",
        "example": "10"
      }
    }
  },
  "marinara_pomodoro_assistant": {
    "message": "Marinara: msaidizi wa Pomodoro",
    "description": "Settings page title."
  },
  "settings": {
    "message": "mipangilio",
    "description": "Settings tab. Shown on the settings page."
  },
  "history": {
    "message": "Historia",
    "description": "History tab. Shown on the settings page."
  },
  "feedback": {
    "message": "Maoni",
    "description": "Feedback tab and section header. Shown on the settings page."
  },
  "focus": {
    "message": "Zingatia",
    "description": "Focus section header. Shown on the settings page."
  },
  "short_break": {
    "message": "Likizo fupi",
    "description": "Short Break section header. Shown on the settings page."
  },
  "long_break": {
    "message": "Likizo ndefu",
    "description": "Long Break section header. Shown on the settings page."
  },
  "autostart_title": {
    "message": "Otomati",
    "description": "Autostart section header. Shown on the settings page."
  },
  "autostart_description": {
    "message": "Panga Pomodoro ili kuanza otomatiki kwa wakati uliowekwa.",
    "description": "Autostart setting description. Shown on the settings page."
  },
  "autostart_notification_title": {
    "message": "Otomati Pomodoro",
    "description": "Autostart notification title. Shown in browser notifications when the autostart Pomodoro starts."
  },
  "autostart_notification_message": {
    "message": "Pomodoro iliyopangwa ilianzishwa moja kwa moja",
    "description": "Autostart notification message. Shown in browser notifications when the autostart Pomodoro starts."
  },
  "time": {
    "message": "Muda:",
    "description": "Time input label. Shown on the settings page."
  },
  "duration": {
    "message": "Kipindi:",
    "description": "Timer duration label. Shown on the settings page."
  },
  "minutes": {
    "message": "Dakika",
    "description": "Minutes label for timer duration. Shown on the settings page."
  },
  "timer_sound_label": {
    "message": "Sauti ya saa",
    "description": "Timer sound label. Shown on the settings page."
  },
  "hover_preview": {
    "message": "Pitisha kuhakiki",
    "description": "Hover to preview note. Shown on the settings page."
  },
  "speed_label": {
    "message": "Spidi:",
    "description": "Timer sound speed label. Shown on the settings page."
  },
  "bpm": {
    "message": "Biti kwa dakika",
    "description": "Beats per minute; speed unit for timer sound. Shown on the settings page."
  },
  "none": {
    "message": "Hakun",
    "description": "The 'no sound' option. Represents nothing selected. Shown on the settings page."
  },
  "countdown_timer": {
    "message": "muda wa kuhesabu",
    "description": "Countdown timer label. Shown on the settings page."
  },
  "width": {
    "message": "Upana",
    "description": "Width input placeholder. Refers to countdown window width in pixels."
  },
  "height": {
    "message": "Urefu",
    "description": "Height input placeholder. Refers to countdown window height in pixels."
  },
  "do_not_show": {
    "message": "Usioneshe",
    "description": "Countdown timer visibility option. Shown on the settings page."
  },
  "show_in_tab": {
    "message": "Onesha kwenye tab mpya",
    "description": "Countdown timer visibility option. Shown on the settings page."
  },
  "show_in_window": {
    "message": "onyesha kwenye kidirisha cha kidukizo",
    "description": "Countdown timer visibility option. Shown on the settings page."
  },
  "fullscreen": {
    "message": "Skrini kamili",
    "description": "Countdown timer resolution option for a fullscreen (maximized) countdown timer. Shown on the settings page."
  },
  "custom": {
    "message": "Mila",
    "description": "Countdown timer resolution option. Lets the user specify their own countdown window resolution. Shown on the settings page."
  },
  "countdown_autoclose_tab": {
    "message": "Funga tab kipindi kikiisha",
    "description": "Countdown timer option. Specifies if the countdown tab should close when the session ends. Shown on the settings page."
  },
  "countdown_autoclose_window": {
    "message": "Funga dirisha kipindi kikiisha",
    "description": "Countdown timer option. Specifies if the countdown window should close when the session ends. Shown on the settings page."
  },
  "when_complete": {
    "message": "Ikiisha",
    "description": "Section label for events to fire when timer completes. Shown on the settings page."
  },
  "show_desktop_notification": {
    "message": "Onesha arifu ya desktopu",
    "description": "Desktop notification option. Shown on the settings page."
  },
  "show_new_tab_notification": {
    "message": "Nioneshe muarifu mpya wa tab",
    "description": "New tab notification option. Shown on the settings page."
  },
  "play_audio_notification": {
    "message": "Cheza sauti:",
    "description": "Audio notification label. Shown on the settings page."
  },
  "take_a_long_break_setting": {
    "message": "Chukua likizo ndefu",
    "description": "Long break settings label. Shown on the settings page."
  },
  "never": {
    "message": "Kamwe",
    "description": "Long break option. Shown in the long break dropdown on the settings page."
  },
  "every_2nd_break": {
    "message": "kila mapumziko ya pili (kubadilika)",
    "description": "Long break option. Shown in the long break dropdown on the settings page."
  },
  "every_3rd_break": {
    "message": "Kila mapumziko ya tatu",
    "description": "Long break option. Shown in the long break dropdown on the settings page."
  },
  "every_4th_break": {
    "message": "Kila mapumziko ya nne",
    "description": "Long break option. Shown in the long break dropdown on the settings page."
  },
  "every_5th_break": {
    "message": "Kila mapumziko ya tano",
    "description": "Long break option. Shown in the long break dropdown on the settings page."
  },
  "every_6th_break": {
    "message": "Kila mapumziko ya sita",
    "description": "Long break option. Shown in the long break dropdown on the settings page."
  },
  "every_7th_break": {
    "message": "Kila mapumziko ya saba",
    "description": "Long break option. Shown in the long break dropdown on the settings page."
  },
  "every_8th_break": {
    "message": "Kila mapumziko ya nane",
    "description": "Long break option. Shown in the long break dropdown on the settings page."
  },
  "every_9th_break": {
    "message": "Kila mapumziko ya tisa",
    "description": "Long break option. Shown in the long break dropdown on the settings page."
  },
  "every_10th_break": {
    "message": "Kila mapumziko ya kumi",
    "description": "Long break option. Shown in the long break dropdown on the settings page."
  },
  "tone": {
    "message": "Sauti",
    "description": "Sound name. Shown in the audio notification dropdown in settings."
  },
  "electronic_chime": {
    "message": "Chime ya kielekroniki",
    "description": "Sound name. Shown in the audio notification dropdown in settings."
  },
  "today": {
    "message": "Leo",
    "description": "Pomodoro stats label. Shown on the settings-history page."
  },
  "this_week": {
    "message": "Wiki hii",
    "description": "Pomodoro stats label. Shown on the settings-history page."
  },
  "this_month": {
    "message": "Mwezi huu",
    "description": "Pomodoro stats label. Shown on the settings-history page."
  },
  "total": {
    "message": "Jumla",
    "description": "Pomodoro stats label. Shown on the settings-history page."
  },
  "daily_distribution": {
    "message": "usambazaji wa kila siku",
    "description": "Daily distribution section header. Shown on the settings-history page."
  },
  "weekly_distribution": {
    "message": "Usambazaji wa kila wiki",
    "description": "Weekly distribution section header. Shown on the settings-history page."
  },
  "last_9_months": {
    "message": "$hesabu$ ya miezi tisa iliyopita",
    "description": "Last 9 months section header. Shown on the settings-history page.",
    "placeholders": {
      "count": {
        "content": "$1",
        "example": "No Pomodoros"
      }
    }
  },
  "daily_empty_placeholder": {
    "message": "Maliza Pomodoro kuona takwimu zako za kila siku",
    "description": "Placeholder for daily stats when no Pomodoros have been completed. Shown on the settings-history page."
  },
  "weekly_empty_placeholder": {
    "message": "Maliza Pomodoro kuona takwimu zako za kila wiki",
    "description": "Placeholder for weekly stats when no Pomodoros have been completed. Shown on the settings-history page."
  },
  "history_empty_placeholder": {
    "message": "Maliza Pomodoro kuona historia yako",
    "description": "Placeholder for history heatmap when no Pomodoros have been completed. Shown on the settings-history page."
  },
  "daily_tooltip": {
    "message": "$pomodoros$ katikati $anza$-$mwisho$",
    "description": "Tooltip for daily distribution chart. Shown on the settings-history page.",
    "placeholders": {
      "pomodoros": {
        "content": "$1",
        "example": "15 Pomodoros"
      },
      "start": {
        "content": "$2",
        "example": "9:00a"
      },
      "end": {
        "content": "$3",
        "example": "10:00a"
      }
    }
  },
  "weekly_tooltip": {
    "message": "$pomodoros$ ya $siku$",
    "description": "Tooltip for weekly distribution chart. Shown on the settings-history page.",
    "placeholders": {
      "pomodoros": {
        "content": "$1",
        "example": "25 Pomodoros"
      },
      "day": {
        "content": "$2",
        "example": "Mondays"
      }
    }
  },
  "heatmap_tooltip": {
    "message": "$pomodoros$ ya $tarehe$",
    "description": "Tooltip for heatmap chart. Shown on the settings-history page.",
    "placeholders": {
      "pomodoros": {
        "content": "$1",
        "example": "25 Pomodoros"
      },
      "date": {
        "content": "$2",
        "example": "Jun 07, 2017"
      }
    }
  },
  "decimal_separator": {
    "message": ".",
    "description": "Separator for fractional numbers (e.g. three-and-a-half: 3.5)."
  },
  "thousands_separator": {
    "message": ",",
    "description": "Group separator for large numbers (e.g. two thousand: 2,000)."
  },
  "heatmap_date_format": {
    "message": "%A, %B %d, %Y",
    "description": "Heatmap tooltip date format. See format options at https://github.com/d3/d3-time-format/blob/master/README.md#locale_format. Shown on the settings-history page."
  },
  "hour_format": {
    "message": "%-I%p",
    "description": "Hour-only format. See format options at https://github.com/d3/d3-time-format/blob/master/README.md#locale_format. Shown on the daily distribution chart on the settings-history page."
  },
  "hour_minute_format": {
    "message": "%-I:%M%p",
    "description": "Hour-with-minutes format. See format options at https://github.com/d3/d3-time-format/blob/master/README.md#locale_format. Shown in the daily distribution chart tooltips on the settings-history page."
  },
  "date_format": {
    "message": "%-m/%-d/%Y",
    "description": "Date-only format. See format options at https://github.com/d3/d3-time-format/blob/master/README.md#locale_format."
  },
  "date_time_format": {
    "message": "%x, %X",
    "description": "Date-with-time format. See format options at https://github.com/d3/d3-time-format/blob/master/README.md#locale_format."
  },
  "time_format": {
    "message": "%-I:%M:%S %p",
    "description": "Time-only format. See format options at https://github.com/d3/d3-time-format/blob/master/README.md#locale_format."
  },
  "time_period_am": {
    "message": "a",
    "description": "12-hour clock AM specifier. Can be empty if 24-hour clock is used. See format options at https://github.com/d3/d3-time-format/blob/master/README.md#locale_format."
  },
  "time_period_pm": {
    "message": "p",
    "description": "12-hour clock PM specifier. Can be empty if 24-hour clock is used. See format options at https://github.com/d3/d3-time-format/blob/master/README.md#locale_format."
  },
  "sunday": {
    "message": "Jumapili",
    "description": "Sunday. Shown on the settings-history page."
  },
  "monday": {
    "message": "Jumatatu",
    "description": "Monday. Shown on the settings-history page."
  },
  "tuesday": {
    "message": "Jumanne",
    "description": "Tuesday. Shown on the settings-history page."
  },
  "wednesday": {
    "message": "Jumatano",
    "description": "Wednesday. Shown on the settings-history page."
  },
  "thursday": {
    "message": "Alhamis",
    "description": "Thursday. Shown on the settings-history page."
  },
  "friday": {
    "message": "Ijumaa",
    "description": "Friday. Shown on the settings-history page."
  },
  "saturday": {
    "message": "Jumamosi",
    "description": "Saturday. Shown on the settings-history page."
  },
  "sunday_short": {
    "message": "Jpili",
    "description": "Sunday abbreviated. Shown on the settings-history page."
  },
  "monday_short": {
    "message": "Jtatu",
    "description": "Monday abbreviated. Shown on the settings-history page."
  },
  "tuesday_short": {
    "message": "Jnne",
    "description": "Tuesday abbreviated. Shown on the settings-history page."
  },
  "wednesday_short": {
    "message": "Jtano",
    "description": "Wednesday abbreviated. Shown on the settings-history page."
  },
  "thursday_short": {
    "message": "Alhamis",
    "description": "Thursday abbreviated. Shown on the settings-history page."
  },
  "friday_short": {
    "message": "Ijumaa",
    "description": "Friday abbreviated. Shown on the settings-history page."
  },
  "saturday_short": {
    "message": "Jmosi",
    "description": "Saturday abbreviated. Shown on the settings-history page."
  },
  "january": {
    "message": "Januari",
    "description": "January. Shown on the settings-history page."
  },
  "february": {
    "message": "Februari",
    "description": "February. Shown on the settings-history page."
  },
  "march": {
    "message": "Machi",
    "description": "March. Shown on the settings-history page."
  },
  "april": {
    "message": "Aprili",
    "description": "April. Shown on the settings-history page."
  },
  "may": {
    "message": "Mei",
    "description": "May. Shown on the settings-history page."
  },
  "june": {
    "message": "Juni",
    "description": "June. Shown on the settings-history page."
  },
  "july": {
    "message": "Julai",
    "description": "July. Shown on the settings-history page."
  },
  "august": {
    "message": "Agosti",
    "description": "August. Shown on the settings-history page."
  },
  "september": {
    "message": "Septemba",
    "description": "September. Shown on the settings-history page."
  },
  "october": {
    "message": "Oktoba",
    "description": "October. Shown on the settings-history page."
  },
  "november": {
    "message": "Novemba",
    "description": "November. Shown on the settings-history page."
  },
  "december": {
    "message": "Desemba",
    "description": "December. Shown on the settings-history page."
  },
  "january_short": {
    "message": "Januari",
    "description": "January abbreviated. Shown on the settings-history page."
  },
  "february_short": {
    "message": "Februari",
    "description": "February abbreviated. Shown on the settings-history page."
  },
  "march_short": {
    "message": "Machi",
    "description": "March abbreviated. Shown on the settings-history page."
  },
  "april_short": {
    "message": "Aprili",
    "description": "April abbreviated. Shown on the settings-history page."
  },
  "may_short": {
    "message": "Mei",
    "description": "May abbreviated. Shown on the settings-history page."
  },
  "june_short": {
    "message": "Juni",
    "description": "June abbreviated. Shown on the settings-history page."
  },
  "july_short": {
    "message": "Julai",
    "description": "July abbreviated. Shown on the settings-history page."
  },
  "august_short": {
    "message": "Agosti",
    "description": "August abbreviated. Shown on the settings-history page."
  },
  "september_short": {
    "message": "Septemba",
    "description": "September abbreviated. Shown on the settings-history page."
  },
  "october_short": {
    "message": "Oktoba",
    "description": "October abbreviated. Shown on the settings-history page."
  },
  "november_short": {
    "message": "Novemba",
    "description": "November abbreviated. Shown on the settings-history page."
  },
  "december_short": {
    "message": "Desemba",
    "description": "December abbreviated. Shown on the settings-history page."
  },
  "your_history": {
    "message": "Historia yako",
    "description": "Your History section header. Shown on the settings-history page."
  },
  "save_as_csv_description": {
    "message": "Tumia na Excel, Laha za Google, au programu nyingine ya lahajedwali.",
    "description": "Save as CSV description. Shown on the settings-history page."
  },
  "end_date": {
    "message": "Tarehe ya mwisho",
    "description": "CSV column header for the Pomodoro's end date in YYYY-MM-DD format."
  },
  "end_time": {
    "message": "Muda wa mwisho (masaa 24)",
    "description": "CSV column header for the Pomodoro's end time formatted as time on a 24-hour clock."
  },
  "end_timestamp": {
    "message": "Mwisho wa stamp ya muda (Unix)",
    "description": "CSV column header for the Pomodoro's end time formatted as a Unix timestamp. See https://en.wikipedia.org/wiki/Unix_time."
  },
  "end_timezone": {
    "message": "Mwisho Timezone (Dakika za kukabiliana na UTC)",
    "description": "CSV column header for the Pomodoro's end timezone defined as the GMT/UTC (Coordinated Universal Time) offset, measured in minutes."
  },
  "duration_seconds": {
    "message": "Kipindi (sekunde)",
    "description": "CSV column header for the Pomodoro's duration in seconds."
  },
  "export": {
    "message": "usafirishaji",
    "description": "Export (history) button. Shown on the settings-history page."
  },
  "export_description": {
    "message": "Kwa chelezo au kuagiza kwenye kompyuta nyingine.",
    "description": "Export history description. Shown on the settings-history page."
  },
  "import": {
    "message": "Kuagiza",
    "description": "Import (history) button. Shown on the settings-history page."
  },
  "import_description": {
    "message": "Ingiza na unganisha historia ya Pomodoro kutoka faili iliyosafirishwa.",
    "description": "Import history description. Shown on the settings-history page."
  },
  "import_confirmation": {
    "message": "Historia iliyoingizwa itaunganishwa na historia yako iliyopo. Endelea?",
    "description": "Import history confirmation prompt. Shown on the settings-history page."
  },
  "import_failed": {
    "message": "Imeshindwa kuleta historia: $kosa$",
    "description": "Error message shown when history import fails. Shown on the settings-history page.",
    "placeholders": {
      "error": {
        "content": "$1",
        "example": "Missing Pomodoro data."
      }
    }
  },
  "clear_history": {
    "message": "Futa historia",
    "description": "Clear History button. Shown on the settings-history page."
  },
  "clear_history_description": {
    "message": "Futa kabisa historia yote ya Pomodoro.",
    "description": "Clear history description. Shown on the settings-history page."
  },
  "clear_history_confirmation": {
    "message": "Futa kabisa historia yote ya Pomodoro?",
    "description": "Clear history confirmation prompt. Shown when user clicks Clear History on the settings-history page."
  },
  "group_pomodoros_minute_buckets": {
    "message": "Pomodoros ya kikundi ndani ya $hesabu$ ndoo ya dakika",
    "description": "Daily distribution bucket tooltip. Shown on the settings-history page.",
    "placeholders": {
      "count": {
        "content": "$1",
        "example": "15"
      }
    }
  },
  "group_pomodoros_hour_buckets": {
    "message": "Pomodoros ya kikundi ndani ya $hesabu$ ndoo ya masaa",
    "description": "Daily distribution bucket tooltip. Shown on the settings-history page.",
    "placeholders": {
      "count": {
        "content": "$1",
        "example": "2"
      }
    }
  },
  "min_suffix": {
    "message": "$hesabu$ Dakika",
    "description": "Number with minute suffix (abbreviated). Shown on the settings-history page.",
    "placeholders": {
      "count": {
        "content": "$1",
        "example": "15"
      }
    }
  },
  "hr_suffix": {
    "message": "$hesabu$ Saa",
    "description": "Number with hour suffix (abbreviated). Shown on the settings-history page.",
    "placeholders": {
      "count": {
        "content": "$1",
        "example": "2"
      }
    }
  },
  "write_a_review": {
    "message": "Andika uhakiki",
    "description": "Link to write a review on Chrome Web Store. Shown on the settings-feedback page."
  },
  "report_an_issue": {
    "message": "Ripoti suala",
    "description": "Link to report an issue on GitHub. Shown on the settings-feedback page."
  },
  "release_notes": {
    "message": "maelezo ya kutolewa",
    "description": "Link to GitHub release notes. Shown on the settings-feedback page."
  },
  "source_code": {
    "message": "msimbo wa chanzo",
    "description": "Link to GitHub source code. Shown on the settings-feedback page."
  },
  "attributions": {
    "message": "Sifa",
    "description": "Link to audio attributions. Shown on the settings-feedback page."
  },
  "license": {
    "message": "Leseni",
    "description": "Link to source license. Shown on the settings-feedback page."
  },
  "view": {
    "message": "Mtazamo",
    "description": "View section header. Shown on the settings-feedback page."
  },
  "version": {
    "message": "Toleo",
    "description": "Version section header. Shown on the settings-feedback page."
  },
  "disclaimer": {
    "message": "Pomodoro ️️ na Mbinu ya Pomodoro  ️ ni alama za biashara za Francesco Cirillo. Marinara havihusiani na au kuhusishwa na au kupitishwa na Pomodoro®️, Mbinu ya Pomodoro ®️ au Francesco Cirillo.",
    "description": "Disclaimer footer text. Shown on the settings-feedback page."
  },
  "and": {
    "message": "Na",
    "description": "Connector of 'Chris Schmich & Contributors'. Shown on the settings-feedback page."
  },
  "contributors": {
    "message": "Wachangiaji",
    "description": "Part of 'Chris Schmich & Contributors'. Shown on the settings-feedback page."
  },
  "completed_today": {
    "message": "Imemalizika leo",
    "description": "Label for today's completed Pomodoro count. Shown on the timer expiration page."
  },
  "view_history": {
    "message": "Angalia historia",
    "description": "View History button text. Shown on the timer expiration page."
  },
  "pomodoros_until_long_break": {
    "message": "$pomodoros$ hadi likizo ndefu",
    "description": "Pomodoro long break countdown. Shown on the timer expiration page and in browser notifications.",
    "placeholders": {
      "pomodoros": {
        "content": "$1",
        "example": "5 Pomodoros"
      }
    }
  },
  "pomodoros_completed_today": {
    "message": "$pomodoros$ leo",
    "description": "Daily Pomodoro counter. Should be short enough to fit in browser notification box. Shown in browser notifications.",
    "placeholders": {
      "pomodoros": {
        "content": "$1",
        "example": "1 Pomodoro"
      }
    }
  },
  "start_focusing_now": {
    "message": "Anza kuzingatia sasa",
    "description": "Notification button text when break timer expires."
  },
  "take_a_break": {
    "message": "Chukua likizo",
    "description": "Action title. Shown on the timer expiration page and in browser notifications."
  },
  "take_a_short_break": {
    "message": "Chuka likizo fupi",
    "description": "Action title. Shown on the timer expiration page and in browser notifications."
  },
  "take_a_long_break": {
    "message": "Chukua likizo ndefu",
    "description": "Action title. Shown on the timer expiration page and in browser notifications."
  },
  "start_break_now": {
    "message": "Anza likizo sasa",
    "description": "Notification button text when focus timer expires."
  },
  "start_short_break_now": {
    "message": "Anza likizo fupi sasa",
    "description": "Notification button text when focus timer expires."
  },
  "start_long_break_now": {
    "message": "Anza likizo ndefu sasa",
    "description": "Notification button text when focus timer expires."
  },
  "browser_action_tooltip": {
    "message": "$kichwa$: $maandishi$",
    "description": "Browser action tooltip format with title and text. Title is usually timer phase (break, focus) while text is usually timer status (time remaining, paused).",
    "placeholders": {
      "title": {
        "content": "$1",
        "example": "Short Break"
      },
      "text": {
        "content": "$2",
        "example": "5m remaining"
      }
    }
  },
  "n_minutes": {
    "message": "$hesabu$m",
    "description": "Badge tooltip and overlay text when timer has least 1 minute remaining.",
    "placeholders": {
      "count": {
        "content": "$1",
        "example": "15"
      }
    }
  },
  "less_than_minute": {
    "message": "<1m",
    "description": "Badge tooltip and overlay text when timer has less than 1 minute remaining."
  },
  "time_remaining": {
    "message": "$muda$ Uliobaki",
    "description": "Badge tooltip to show time remaining for current timer.",
    "placeholders": {
      "time": {
        "content": "$1",
        "example": "5m"
      }
    }
  },
  "missing_pomodoro_data": {
    "message": "data ya Pomodoro inayokosekana",
    "description": "Error when imported history has no Pomodoro information."
  },
  "invalid_pomodoro_data": {
    "message": "Data ya Pomodoro batili",
    "description": "Error when imported history has invalid Pomodoro information."
  },
  "missing_duration_data": {
    "message": "data ya Kipindi kinachokosekana",
    "description": "Error when imported history has no Pomodoro duration information."
  },
  "invalid_duration_data": {
    "message": "Data batili ya kipindi",
    "description": "Error when imported history has invalid duration information."
  },
  "missing_timezone_data": {
    "message": "Data ya timezone inayokosekana",
    "description": "Error when imported history has no Pomodoro timezone information."
  },
  "invalid_timezone_data": {
    "message": "Data batili ya timezone",
    "description": "Error when imported history has invalid timezone information."
  },
  "mismatched_pomodoro_duration_data": {
    "message": "Takwimu isiyo na kipimo ya Pomodoro / muda",
    "description": "Error when imported history has mismatched Pomodoro/duration data."
  },
  "mismatched_pomodoro_timezone_data": {
    "message": "Takwimu isiyo sahihi ya Pomodoro / timezone.",
    "description": "Error when imported history has mismatched Pomodoro/timezone data."
  },
  "pomodoros_imported": {
    "message": "$pomodoros$ zilizoingizwa",
    "description": "Count of Pomodoros imported. Shown in prompt after importing/merging Pomodoro history.",
    "placeholders": {
      "pomodoros": {
        "content": "$1",
        "example": "3 Pomodoros"
      }
    }
  },
  "help_translate": {
    "message": "msaada kutafsiri",
    "description": "Feedback link. Shown on settings-feedback page."
  },
  "expire_title": {
    "message": "Muda umekwisha",
    "description": "Expiration page title. Shown on the expiration page when a focus/break session completes."
  },
  "countdown": {
    "message": "Kuhesabu",
    "description": "Countdown page title. Shown on the countdown timer page."
  },
  "gong_1": {
    "message": "Gong 1",
    "description": "Sound name. Shown in the audio notification dropdown in settings."
  },
  "gong_2": {
    "message": "Gong 2",
    "description": "Sound name. Shown in the audio notification dropdown in settings."
  },
  "computer_magic": {
    "message": "Uchawi wa kompyuta",
    "description": "Sound name. Shown in the audio notification dropdown in settings."
  },
  "fire_pager": {
    "message": "pager ya mbele",
    "description": "Sound name. Shown in the audio notification dropdown in settings."
  },
  "glass_ping": {
    "message": "glasi ya glasi",
    "description": "Sound name. Shown in the audio notification dropdown in settings."
  },
  "music_box": {
    "message": "sanduku la muziki",
    "description": "Sound name. Shown in the audio notification dropdown in settings."
  },
  "pin_drop": {
    "message": "kushuka kwa siri",
    "description": "Sound name. Shown in the audio notification dropdown in settings."
  },
  "robot_blip_1": {
    "message": "Roboti blip 1",
    "description": "Sound name. Shown in the audio notification dropdown in settings."
  },
  "robot_blip_2": {
    "message": "Roboti blip 2",
    "description": "Sound name. Shown in the audio notification dropdown in settings."
  },
  "ship_bell": {
    "message": "Kengele ya meli",
    "description": "Sound name. Shown in the audio notification dropdown in settings."
  },
  "train_horn": {
    "message": "Honi ya treni",
    "description": "Sound name. Shown in the audio notification dropdown in settings."
  },
  "bike_horn": {
    "message": "Honi ya baiskeli",
    "description": "Sound name. Shown in the audio notification dropdown in settings."
  },
  "bell_ring": {
    "message": "Kengele",
    "description": "Sound name. Shown in the audio notification dropdown in settings."
  },
  "reception_bell": {
    "message": "Kengele ya mapokezi",
    "description": "Sound name. Shown in the audio notification dropdown in settings."
  },
  "toaster_oven": {
    "message": "Tosta ya oveni",
    "description": "Sound name. Shown in the audio notification dropdown in settings."
  },
  "battle_horn": {
    "message": "Honi ya vita",
    "description": "Sound name. Shown in the audio notification dropdown in settings."
  },
  "ding": {
    "message": "ding",
    "description": "Sound name. Shown in the audio notification dropdown in settings."
  },
  "dong": {
    "message": "dong",
    "description": "Sound name. Shown in the audio notification dropdown in settings."
  },
  "ding_dong": {
    "message": "ding dong",
    "description": "Sound name. Shown in the audio notification dropdown in settings."
  },
  "airplane": {
    "message": "Ndege",
    "description": "Sound name. Shown in the audio notification dropdown in settings."
  },
  "digital_watch": {
    "message": "Saa ya dijiti",
    "description": "Sound name. Shown in the audio notification dropdown in settings."
  },
  "analog_alarm_clock": {
    "message": "Saa ya kengele ya analojia",
    "description": "Sound name. Shown in the audio notification dropdown in settings."
  },
  "digital_alarm_clock": {
    "message": "Saa ya kengele ya dijitali",
    "description": "Sound name. Shown in the audio notification dropdown in settings."
  },
  "periodic_beat": {
    "message": "kupigwa mara kwa mara",
    "description": "Timer sound group name. Shown in the timer sound dropdown in settings."
  },
  "stopwatch": {
    "message": "Saa ya kustop",
    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
  },
  "clock": {
    "message": "Saa",
    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
  },
  "wall_clock": {
    "message": "Saa ya ukutani",
    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
  },
  "desk_clock": {
    "message": "Saa ya mezani",
    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
  },
  "antique_clock": {
    "message": "Saa ya kale",
    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
  },
  "small_clock": {
    "message": "Saa ndogo",
    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
  },
  "large_clock": {
    "message": "Saa kubwa",
    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
  },
  "wristwatch": {
    "message": "Saa ya mkononi",
    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
  },
  "wind_up_clock": {
    "message": "Upepo saa",
    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
  },
  "metronome": {
    "message": "Metronome",
    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
  },
  "wood_block": {
    "message": "Block ya kuni",
    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
  },
  "pulse": {
    "message": "Kunde",
    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
  },
  "noise": {
    "message": "Kelele",
    "description": "Timer sound group name. Shown in the timer sound dropdown in settings."
  },
  "brown_noise": {
    "message": "Kelele ya kahawia",
    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
  },
  "pink_noise": {
    "message": "Kelele ya pink",
    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
  },
  "white_noise": {
    "message": "mipangilio ime",
    "description": "Timer sound name. Shown in the timer sound dropdown in settings."
  },
  "settings_saved": {
    "message": "mipangilio imehifadhiwa",
    "description": "Settings Saved notification shown on settings page when settings are saved."
  },
  "error_saving_settings": {
    "message": "Kosa la kuokoa mipangilio: $ujumbe$",
    "description": "Shown to the user in an alert when settings can't be saved due to user input error or unexpected error.",
    "placeholders": {
      "message": {
        "content": "$1",
        "example": "Duration must be a positive number."
      }
    }
  }
}