### PR TITLE
resume timer after the computer wake up from sleep mode

### DIFF
--- a/src/background/Timer.js
+++ b/src/background/Timer.js
@@ -16,11 +16,10 @@ class Timer extends EventEmitter
     this.duration = duration;
     this.tick = tick;
 
-    this.tickInterval = null;
-    this.expireTimeout = null;
-
     this.checkpointStartAt = null;
     this.checkpointElapsed = 0;
+
+    this.countdownInterval = null;
   }
 
   observe(observer) {
@@ -72,11 +71,11 @@ class Timer extends EventEmitter
       return;
     }
 
-    this.setExpireTimeout(this.duration);
-    this.setTickInterval(this.tick);
+    this.checkpointStartAt = Date.now();
+
+    this.countdown();
 
     this.state = TimerState.Running;
-    this.checkpointStartAt = Date.now();
 
     this.emit('start', this.status);
   }
@@ -86,11 +85,9 @@ class Timer extends EventEmitter
       return;
     }
 
-    clearInterval(this.tickInterval);
-    clearTimeout(this.expireTimeout);
+    clearInterval(this.countdownInterval);
+    this.countdownInterval = null;
 
-    this.tickInterval = null;
-    this.expireTimeout = null;
     this.checkpointStartAt = null;
     this.checkpointElapsed = 0;
 
@@ -104,8 +101,7 @@ class Timer extends EventEmitter
       return;
     }
 
-    clearInterval(this.tickInterval);
-    clearTimeout(this.expireTimeout);
+    clearInterval(this.countdownInterval);
 
     let periodElapsed = (Date.now() - this.checkpointStartAt) / 1000;
     this.checkpointElapsed += periodElapsed;
@@ -120,11 +116,11 @@ class Timer extends EventEmitter
       return;
     }
 
-    this.setExpireTimeout(this.remaining);
-    this.setTickInterval(this.tick);
+    this.checkpointStartAt = Date.now();
+
+    this.countdown();
 
     this.state = TimerState.Running;
-    this.checkpointStartAt = Date.now();
 
     this.emit('resume', this.status);
   }
@@ -134,26 +130,36 @@ class Timer extends EventEmitter
     this.start();
   }
 
-  setExpireTimeout(seconds) {
-    this.expireTimeout = setTimeout(() => {
-      clearInterval(this.tickInterval);
-      clearTimeout(this.expireTimeout);
+  expire() {
+    clearInterval(this.countdownInterval);
+    this.countdownInterval = null;
 
-      this.tickInterval = null;
-      this.expireTimeout = null;
-      this.checkpointStartAt = Date.now();
-      this.checkpointElapsed = this.duration;
+    this.checkpointStartAt = null;
+    this.checkpointElapsed = 0;
 
-      this.state = TimerState.Stopped;
+    this.state = TimerState.Stopped;
 
-      this.emit('expire', this.status);
-    }, seconds * 1000);
+    this.emit('expire', this.status);
   }
 
-  setTickInterval(seconds) {
-    this.tickInterval = setInterval(() => {
-      this.emit('tick', this.status);
-    }, seconds * 1000);
+  countdown() {
+    const expireAt = this.checkpointStartAt + this.remaining * 1000;
+    let nextTickAt = this.checkpointStartAt + this.periodBeforeNextTick() * 1000;
+
+    this.countdownInterval = setInterval(() => {
+      const now = Date.now();
+
+      if (now >= expireAt) {
+        this.expire();
+      } else if (now >= nextTickAt) {
+        this.emit('tick', this.status);
+        nextTickAt = now + this.periodBeforeNextTick() * 1000;
+      }
+    }, 1000);
+  }
+
+  periodBeforeNextTick() {
+    return this.tick - ((this.elapsed + this.tick) % this.tick);
   }
 }
 


### PR DESCRIPTION
## Background

(Attempt to fix #296 and the related issues.)

When the computer sleeps, the timer's `tickInterval` and `expireTimeout` will be paused by the system. When the system wakes up, the timer is resumed without acknowledging the paused period. This appears to the users that the timer is frozen.

## Changes

* Replace `ticketInterval` and `expireTimeout` with a single `countdownInterval`.
* `countdownInterval` runs every second to compare `checkpointStartAt` to track the time - the timer can tick/expire correctly as soon as the script resumes from sleep mode.

## Experiment

```
09:17:58.789 Timer.js:74 started
09:17:58.790 Timer.js:157 countdown
09:17:58.790 Timer.js:158 expireAt 2021-09-12T09:27:58.789Z
09:17:58.790 Timer.js:159 nextTickAt 2021-09-12T09:18:58.789Z
09:18:58.796 Timer.js:170 tick 1
09:18:58.800 Timer.js:173 nextTickAt 2021-09-12T09:19:58.785Z
09:19:58.795 Timer.js:170 tick 2
09:19:58.798 Timer.js:173 nextTickAt 2021-09-12T09:20:58.786Z
09:20:58.799 Timer.js:170 tick 3
09:20:58.804 Timer.js:173 nextTickAt 2021-09-12T09:21:58.784Z
09:26:06.911 Timer.js:170 tick 4
09:26:07.307 Timer.js:173 nextTickAt 2021-09-12T09:26:58.393Z
09:26:59.099 Timer.js:170 tick 5
09:26:59.102 Timer.js:173 nextTickAt 2021-09-12T09:27:58.786Z
09:27:59.101 Timer.js:167 expire 6
```

The computer slept after `tick 3` at around 09:20:58. When the computer resumed at around 09:26:06, `tick 4` happened immediately and updated `nextTickAt` to the correct time. Finally, the timer expired at 09:27:59 as expected.