### PR TITLE
Fixed the unreferenced variable in a locale file

### DIFF
--- a/package/_locales/ja/messages.json
+++ b/package/_locales/ja/messages.json
@@ -264,7 +264,7 @@
     "description": "Weekly distribution section header. Shown on the settings-history page."
   },
   "last_9_months": {
-    "message": "直近9か月間で$counts$",
+    "message": "直近9か月間で$count$",
     "description": "Last 9 months section header. Shown on the settings-history page.",
     "placeholders": {
       "count": {


### PR DESCRIPTION
The variable name "counts" is not referenced correctly. As a result, it would cause an error in a `make` command. For insatnce, 

```
$ make release package
ruby -Iscripts scripts/validate-messages.rb
Error in package/_locales/ja/messages.json, last_9_months:
        Placeholder referenced but not defined: $counts$
make: *** [validate-messages] Error 1
```

edit: it's my first time making a PR on an open source project, so please let me know if I am missing anything. Thank you.